### PR TITLE
Ripple effect button

### DIFF
--- a/packages/ripple-effect-button/src/Ripple.tsx
+++ b/packages/ripple-effect-button/src/Ripple.tsx
@@ -2,17 +2,11 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface StyledRippleProps {
-  rippleColor: string;
+  rippleColor?: string;
 }
 
 const StyledRipple = styled.div<StyledRippleProps>`
-  background: ${props => {
-    if (props.rippleColor === 'light') {
-      return 'rgba(255, 255, 255, 0.5)';
-    } else if (props.rippleColor === 'dark') {
-      return 'rgba(0, 0, 0, 0.5)';
-    }
-  }};
+  background: ${props => props.rippleColor ?? 'rgba(0, 0, 0, 0.5)' };
 
   width: 10px;
   height: 10px;
@@ -48,7 +42,7 @@ interface Props {
     x: number,
     y: number
   };
-  rippleColor: 'light' | 'dark';
+  rippleColor?: string;
 }
 
 export default Ripple;

--- a/packages/ripple-effect-button/src/Ripple.tsx
+++ b/packages/ripple-effect-button/src/Ripple.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from 'react'
+import styled from 'styled-components'
 
 interface StyledRippleProps {
-  rippleColor?: string;
+  rippleColor?: string
 }
 
 const StyledRipple = styled.div<StyledRippleProps>`
-  background: ${props => props.rippleColor ?? 'rgba(0, 0, 0, 0.5)' };
+  background: ${(props) => props.rippleColor ?? 'rgba(0, 0, 0, 0.5)'};
 
   width: 10px;
   height: 10px;
@@ -15,14 +15,21 @@ const StyledRipple = styled.div<StyledRippleProps>`
 
   animation: 0.9s forwards ripple-effect;
   @keyframes ripple-effect {
-    0% { transform: scale(1); opacity: 1; }
-    80% { transform: scale(50); }
-    100% { opacity: 0; }
+    0% {
+      transform: scale(1);
+      opacity: 1;
+    }
+    80% {
+      transform: scale(50);
+    }
+    100% {
+      opacity: 0;
+    }
   }
-`;
+`
 
 const Ripple = (props: Props): JSX.Element => {
-  const { onAnimationEnd, coords, rippleColor } = props;
+  const { onAnimationEnd, coords, rippleColor } = props
 
   return (
     <StyledRipple
@@ -30,19 +37,19 @@ const Ripple = (props: Props): JSX.Element => {
       onAnimationEnd={onAnimationEnd}
       style={{
         left: coords.x,
-        top: coords.y
+        top: coords.y,
       }}
     />
   )
-};
-
-interface Props {
-  onAnimationEnd: React.AnimationEventHandler;
-  coords: {
-    x: number,
-    y: number
-  };
-  rippleColor?: string;
 }
 
-export default Ripple;
+interface Props {
+  onAnimationEnd: React.AnimationEventHandler
+  coords: {
+    x: number
+    y: number
+  }
+  rippleColor?: string
+}
+
+export default Ripple

--- a/packages/ripple-effect-button/src/RippleEffectButton.tsx
+++ b/packages/ripple-effect-button/src/RippleEffectButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import styled from 'styled-components';
+import styled from 'styled-components'
 // components
-import Ripple from './Ripple';
+import Ripple from './Ripple'
 
 const StyledButton = styled.button`
   position: relative;
@@ -10,78 +10,78 @@ const StyledButton = styled.button`
   padding: 10px;
   background-color: white;
   cursor: pointer;
-`;
+`
 
 const RippleEffectButton = (props: RippleEffectButtonProps): JSX.Element => {
-  const { children, onClick, rippleColor, ...rest } = props;
+  const { children, onClick, rippleColor, ...rest } = props
 
-  const [rippleKey, setRippleKey] = React.useState(0);
-  const [ripples, setRipples] = React.useState<RippleValues>({});
+  const [rippleKey, setRippleKey] = React.useState(0)
+  const [ripples, setRipples] = React.useState<RippleValues>({})
 
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null)
 
   const makeRipples = (event: React.MouseEvent) => {
-    const $target = buttonRef.current as HTMLButtonElement;
-    const rect = $target.getBoundingClientRect();
+    const $target = buttonRef.current as HTMLButtonElement
+    const rect = $target.getBoundingClientRect()
 
-    let x = event.clientX - rect.left;
-    let y = event.clientY - rect.top;
+    let x = event.clientX - rect.left
+    let y = event.clientY - rect.top
 
     // work on Keyboard Click (Enter, Spacebar)
     if (event.clientX === 0 && event.clientY === 0) {
-      x = $target.clientWidth / 2;
-      y = $target.clientHeight / 2;
+      x = $target.clientWidth / 2
+      y = $target.clientHeight / 2
     }
 
-    setRipples(prevState => {
+    setRipples((prevState) => {
       return { ...prevState, [rippleKey]: { x, y } }
-    });
-    setRippleKey(prevState => prevState + 1);
-  };
+    })
+    setRippleKey((prevState) => prevState + 1)
+  }
 
   const deleteRipple = (event: React.AnimationEvent, key: string) => {
     if (event.animationName === 'ripple-effect') {
-      const newRipples = Object.assign({}, ripples);
-      delete newRipples[key]; // delete Component when animation end
-      setRipples(newRipples);
+      const newRipples = Object.assign({}, ripples)
+      delete newRipples[key] // delete Component when animation end
+      setRipples(newRipples)
     }
-  };
+  }
 
   return (
     <StyledButton
       ref={buttonRef}
-      onClick={event => {
-        makeRipples(event);
-        onClick && onClick(event);
+      onClick={(event) => {
+        makeRipples(event)
+        onClick && onClick(event)
       }}
       {...rest}
     >
       {children}
-      {Object.keys(ripples).map(each => {
+      {Object.keys(ripples).map((each) => {
         return (
           <Ripple
             key={each}
             rippleColor={rippleColor}
-            onAnimationEnd={(event) => deleteRipple(event, each)} 
+            onAnimationEnd={(event) => deleteRipple(event, each)}
             coords={ripples[each]}
           />
-        );
+        )
       })}
     </StyledButton>
-  );
+  )
 }
 
 export interface RippleEffectButtonProps {
-  children: React.ReactNode;
-  onClick?: React.MouseEventHandler;
-  rippleColor?: string;
+  children: React.ReactNode
+  onClick?: React.MouseEventHandler
+  rippleColor?: string
 }
 
 type RippleValues = {
-  [key: string] : {
-    x: number;
-    y: number;
+  [key: string]: {
+    x: number
+    y: number
   }
-};
+}
 
 export default RippleEffectButton

--- a/packages/ripple-effect-button/src/RippleEffectButton.tsx
+++ b/packages/ripple-effect-button/src/RippleEffectButton.tsx
@@ -74,7 +74,7 @@ const RippleEffectButton = (props: RippleEffectButtonProps): JSX.Element => {
 export interface RippleEffectButtonProps {
   children: React.ReactNode;
   onClick?: React.MouseEventHandler;
-  rippleColor: 'light' | 'dark';
+  rippleColor?: string;
 }
 
 type RippleValues = {

--- a/packages/ripple-effect-button/src/RippleEffectButton.tsx
+++ b/packages/ripple-effect-button/src/RippleEffectButton.tsx
@@ -24,13 +24,17 @@ const RippleEffectButton = (props: RippleEffectButtonProps): JSX.Element => {
     const $target = buttonRef.current as HTMLButtonElement;
     const rect = $target.getBoundingClientRect();
 
+    let x = event.clientX - rect.left;
+    let y = event.clientY - rect.top;
+
+    // work on Keyboard Click (Enter, Spacebar)
+    if (event.clientX === 0 && event.clientY === 0) {
+      x = $target.clientWidth / 2;
+      y = $target.clientHeight / 2;
+    }
+
     setRipples(prevState => {
-      return { ...prevState, 
-        [rippleKey]: {
-          x: event.clientX - rect.left,
-          y: event.clientY - rect.top
-        }
-      }
+      return { ...prevState, [rippleKey]: { x, y } }
     });
     setRippleKey(prevState => prevState + 1);
   };

--- a/packages/ripple-effect-button/stories/RippleEffectButton.stories.tsx
+++ b/packages/ripple-effect-button/stories/RippleEffectButton.stories.tsx
@@ -12,8 +12,7 @@ export default {
       control: { type: 'text' }
     },
     rippleColor: {
-      options: ['light', 'dark'],
-      control: { type: 'radio' },
+      control: { type: 'text' },
     },
   },
 } as ComponentMeta<typeof RippleEffectButton>
@@ -27,10 +26,8 @@ const Template = (args: RippleEffectButtonProps) => {
   )
 };
 
-export const LightColorButton = Template.bind({});
-LightColorButton.args = {
-  rippleColor: 'dark',
-};
+export const Default = Template.bind({});
+Default.args = {};
 
 export const DarkColorButton = Template.bind({});
 DarkColorButton.args = {
@@ -38,6 +35,6 @@ DarkColorButton.args = {
     backgroundColor: 'black',
     color: 'white',
   },
-  rippleColor: 'light',
+  rippleColor: 'rgba(255, 255, 255, 0.5)',
 };
 

--- a/packages/ripple-effect-button/stories/RippleEffectButton.stories.tsx
+++ b/packages/ripple-effect-button/stories/RippleEffectButton.stories.tsx
@@ -2,14 +2,16 @@ import React from 'react'
 
 import { ComponentMeta } from '@storybook/react'
 
-import RippleEffectButton, { RippleEffectButtonProps } from '../src/RippleEffectButton'
+import RippleEffectButton, {
+  RippleEffectButtonProps,
+} from '../src/RippleEffectButton'
 
 export default {
   title: 'RippleEffectButton',
   component: RippleEffectButton,
   argTypes: {
     children: {
-      control: { type: 'text' }
+      control: { type: 'text' },
     },
     rippleColor: {
       control: { type: 'text' },
@@ -18,23 +20,22 @@ export default {
 } as ComponentMeta<typeof RippleEffectButton>
 
 const Template = (args: RippleEffectButtonProps) => {
-  const { children, ...rest } = args;
+  const { children, ...rest } = args
   return (
-    <RippleEffectButton {...rest} >
-      {children ?? 'Ripple Effect Button' }
+    <RippleEffectButton {...rest}>
+      {children ?? 'Ripple Effect Button'}
     </RippleEffectButton>
   )
-};
+}
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default = Template.bind({})
+Default.args = {}
 
-export const DarkColorButton = Template.bind({});
+export const DarkColorButton = Template.bind({})
 DarkColorButton.args = {
   style: {
     backgroundColor: 'black',
     color: 'white',
   },
   rippleColor: 'rgba(255, 255, 255, 0.5)',
-};
-
+}


### PR DESCRIPTION
- #33
  - Enter, Spacebar 등의 키보드 입력을 통한 클릭은 좌표값을 얻을 수 없어서 버튼 중앙에서 Ripple 표시되게 함
- #34
  - rippleColor props를 string으로 입력받게 변경
  - rippleColor를 입력하지 않았을 때의 default color 지정
- prettier 적용
 
