### PR TITLE
fix(floating-label-input): add missing dependencies, edit interface, fix eslint warning

### DIFF
--- a/packages/floating-label-input/package.json
+++ b/packages/floating-label-input/package.json
@@ -28,10 +28,12 @@
     "url": "https://github.com/m2-modules/react/issues"
   },
   "dependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "styled-components": "^5.3.1"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
+    "@types/styled-components": "^5.1.14",
     "jest": "^27.1.1",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.2"

--- a/packages/floating-label-input/src/interfaces/index.ts
+++ b/packages/floating-label-input/src/interfaces/index.ts
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export interface IStyledLabel {
   focus: boolean
   underlineColor?: string
@@ -10,6 +12,9 @@ export interface IStyledSpan {
 interface Props {
   label: string
   underlineColor?: string
+  value?: string
+  onChange?: React.ChangeEventHandler<HTMLInputElement>
 }
 
-export type FloatingLabelInputProps = Props & React.InputHTMLAttributes<any>
+export type FloatingLabelInputProps = Props &
+  React.LabelHTMLAttributes<HTMLLabelElement>

--- a/packages/floating-label-input/stories/FloatingLabelInput.stories.tsx
+++ b/packages/floating-label-input/stories/FloatingLabelInput.stories.tsx
@@ -3,45 +3,44 @@ import React from 'react'
 import { ComponentMeta } from '@storybook/react'
 
 import FloatingLabelInput from '../src/FloatingLabelInput'
-import { FloatingLabelInputProps } from '../src/interfaces';
+import { FloatingLabelInputProps } from '../src/interfaces'
 
 export default {
   title: 'FloatingLabelInput',
   component: FloatingLabelInput,
   argTypes: {
     label: {
-      control: { type: 'text' }
+      control: { type: 'text' },
     },
     underlineColor: {
-      control: { type: 'color' }
+      control: { type: 'color' },
     },
     style: {
       width: {
-        control: { type: 'text' } 
-      }
+        control: { type: 'text' },
+      },
     },
-  }
+  },
 } as ComponentMeta<typeof FloatingLabelInput>
 
-export const Basic = (args: FloatingLabelInputProps) => {
-  const { label, underlineColor, ...rest } = args;
+export const Basic = (args: FloatingLabelInputProps): JSX.Element => {
+  const { label, underlineColor, ...rest } = args
 
-  const [value, setValue] = React.useState('');
+  const [value, setValue] = React.useState('')
 
   return (
     <FloatingLabelInput
       label={label}
       value={value}
       underlineColor={underlineColor}
-      onChange={event => setValue(event.target.value)}
+      onChange={(event) => setValue(event.target.value)}
       {...rest}
     />
-  );
-};
+  )
+}
 Basic.args = {
   style: {
     width: '300px',
   },
   label: 'This is Floating Label',
-};
-
+}


### PR DESCRIPTION
- `package.json`
  - `styled-components` 디펜던시 추가
- `index.ts`
  - Label에 InputElement의 type이 제공되고 있던 것 수정
- `stories.tsx`
  - `Basic` 함수에 return type 작성 (fix eslint)