### PR TITLE
feat(underline-radio-button): 밑줄 표시로 선택 표현하는 컴포넌트 개발

### DIFF
--- a/packages/underline-radio-button/.gitignore
+++ b/packages/underline-radio-button/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/underline-radio-button/.npmignore
+++ b/packages/underline-radio-button/.npmignore
@@ -1,0 +1,4 @@
+src
+__tests__
+tsconfig.json
+stories

--- a/packages/underline-radio-button/README.md
+++ b/packages/underline-radio-button/README.md
@@ -1,0 +1,3 @@
+# `Underline Radio Button`
+
+> Underline Radio Button component of M2 modules for React

--- a/packages/underline-radio-button/__tests__/UnderlineRadioButton.test.ts
+++ b/packages/underline-radio-button/__tests__/UnderlineRadioButton.test.ts
@@ -1,0 +1,5 @@
+describe('Underline Radio Button test', () => {
+  it('1 + 2 should equals to 3', () => {
+    expect(1 + 2).toEqual(3)
+  })
+})

--- a/packages/underline-radio-button/package.json
+++ b/packages/underline-radio-button/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@m2-modules/underline-radio-button",
+  "version": "0.0.1",
+  "description": "Underline Radio Button react component",
+  "author": "gincheong2 <gincheong2@gmail.com>",
+  "homepage": "https://github.com/m2-modules/react#readme",
+  "license": "ISC",
+  "main": "dist/index.js",
+  "directories": {
+    "test": "__tests__"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/m2-modules/react.git"
+  },
+  "scripts": {
+    "clean": "rm -rf ./dist",
+    "lint": "eslint ./",
+    "test": "jest",
+    "prebuild": "npm run lint && npm run test",
+    "build": "npm run clean && tsc",
+    "prepublish": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/m2-modules/react/issues"
+  },
+  "dependencies": {
+    "react": "^17.0.2",
+    "styled-components": "^5.3.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^27.0.1",
+    "@types/styled-components": "^5.1.14",
+    "jest": "^27.1.1",
+    "ts-jest": "^27.0.5",
+    "typescript": "^4.4.2"
+  }
+}

--- a/packages/underline-radio-button/src/UnderlineRadioButton.tsx
+++ b/packages/underline-radio-button/src/UnderlineRadioButton.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import styled from 'styled-components'
+// interfaces
+import { StyledLabelProps, UnderlineRadioButtonProps } from './interfaces'
+
+const StyledContainer = styled.div``
+
+const StyledLabel = styled.label<StyledLabelProps>`
+  padding: 5px;
+  position: relative;
+  cursor: pointer;
+
+  &:before {
+    border-bottom: 1px solid #777777;
+    position: absolute;
+    content: '';
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  &:after {
+    border-bottom: 2px solid ${(props) => props.underlineColor ?? 'black'};
+    position: absolute;
+    content: '';
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    transform: ${(props) => (props.checked ? 'scaleX(1)' : 'scaleX(0)')};
+    transition: transform ease-out 0.2s;
+  }
+`
+
+const StyledRadio = styled.input`
+  display: none; // disable default radio button
+`
+
+const UnderlineRadioButton = (
+  props: UnderlineRadioButtonProps
+): JSX.Element => {
+  const { value, name, onChangeRadio, underlineColor, ...rest } = props
+
+  const [checked, setChecked] = React.useState<string>('')
+
+  const onClick = (event: React.MouseEvent) => {
+    const $target = event.target as HTMLInputElement
+
+    if ($target.tagName === 'INPUT') {
+      setChecked($target.value)
+      onChangeRadio && onChangeRadio($target.value)
+    }
+  }
+
+  return (
+    <StyledContainer onClick={onClick}>
+      {value.map((each) => (
+        <StyledLabel
+          key={each.display}
+          checked={each.value === checked}
+          underlineColor={underlineColor}
+          {...rest}
+        >
+          <StyledRadio
+            name={name}
+            value={each.value}
+            checked={each.value === checked}
+          />
+          {each.display ?? each.value}
+        </StyledLabel>
+      ))}
+    </StyledContainer>
+  )
+}
+
+export default UnderlineRadioButton

--- a/packages/underline-radio-button/src/UnderlineRadioButton.tsx
+++ b/packages/underline-radio-button/src/UnderlineRadioButton.tsx
@@ -56,15 +56,17 @@ const UnderlineRadioButton = (
     <StyledContainer onClick={onClick}>
       {value.map((each) => (
         <StyledLabel
-          key={each.display}
+          key={each.value}
           checked={each.value === checked}
           underlineColor={underlineColor}
           {...rest}
         >
           <StyledRadio
+            type="radio"
             name={name}
             value={each.value}
             checked={each.value === checked}
+            readOnly
           />
           {each.display ?? each.value}
         </StyledLabel>

--- a/packages/underline-radio-button/src/index.ts
+++ b/packages/underline-radio-button/src/index.ts
@@ -1,0 +1,3 @@
+import UnderlineRadioButton from './UnderlineRadioButton'
+
+export default UnderlineRadioButton

--- a/packages/underline-radio-button/src/interfaces/index.ts
+++ b/packages/underline-radio-button/src/interfaces/index.ts
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export interface StyledLabelProps {
+  checked: boolean
+  underlineColor?: string
+}
+
+export type RadioValue = {
+  display?: string
+  value: string | number
+}
+
+interface Props {
+  value: RadioValue[]
+  name: string
+  underlineColor?: string
+  onChangeRadio?: (value: string) => void
+}
+
+export type UnderlineRadioButtonProps = Props &
+  React.LabelHTMLAttributes<HTMLLabelElement>

--- a/packages/underline-radio-button/stories/UnderlineRadioButton.stories.tsx
+++ b/packages/underline-radio-button/stories/UnderlineRadioButton.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+
+import { ComponentMeta } from '@storybook/react'
+
+import UnderlineRadioButton from '../src/UnderlineRadioButton'
+import { UnderlineRadioButtonProps } from '../src/interfaces'
+
+export default {
+  title: 'UnderlineRadioButton',
+  component: UnderlineRadioButton,
+  argTypes: {
+    underlineColor: {
+      control: 'text',
+    },
+  },
+} as ComponentMeta<typeof UnderlineRadioButton>
+
+const Template = (args: UnderlineRadioButtonProps): JSX.Element => {
+  const [selected, setSelected] = React.useState('')
+
+  return (
+    <div>
+      <h3>current Selected: {selected}</h3>
+      <UnderlineRadioButton
+        onChangeRadio={(value) => setSelected(value)}
+        {...args}
+      />
+    </div>
+  )
+}
+
+export const OnlyValue = Template.bind({})
+OnlyValue.args = {
+  name: 'name',
+  value: [
+    { value: 'radio button1' },
+    { value: 'radio button2' },
+    { value: 'radio button3' },
+  ],
+  style: {
+    margin: '0 10px',
+  },
+}
+
+export const ValueWithDisplayName = Template.bind({})
+ValueWithDisplayName.args = {
+  name: 'name',
+  value: [
+    { value: 'value1', display: 'Display Name1' },
+    { value: 'value2', display: 'Display Name2' },
+    { value: 'value3', display: 'Display Name3' },
+  ],
+  style: {
+    margin: '0 10px',
+  },
+}

--- a/packages/underline-radio-button/tsconfig.json
+++ b/packages/underline-radio-button/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": [
+    "__tests__",
+    "stories",
+    "dist"
+  ]
+}


### PR DESCRIPTION
- 주요 `props`
  - underlineColor? : 밑줄로 표시되는 색상 입력
  - onChangeRadio? : `(value: string) => void`, 선택된 `radio input`의  `value`가 인자로 전달되는 함수

close #51